### PR TITLE
Bump Go/Node versions, improve frontend build/caching, and disable postmortem workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Cache Go modules
         uses: actions/cache@v4
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -75,14 +75,14 @@ jobs:
           path: |
             web/node_modules
             ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('web/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('web/pnpm-lock.yaml', 'web/package.json') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
 
       - name: Install frontend dependencies
         run: |
           cd web
-          pnpm install
+          pnpm install --no-frozen-lockfile --prefer-offline
 
       - name: Run frontend lint
         run: |

--- a/.github/workflows/postmortem-onboarding.yml
+++ b/.github/workflows/postmortem-onboarding.yml
@@ -2,12 +2,7 @@ name: Postmortem Onboarding
 
 on:
   workflow_dispatch:
-    inputs:
-      force:
-        description: 'Force regenerate all postmortems (skip existing check)'
-        required: false
-        default: 'false'
-        type: boolean
+
 
 permissions:
   contents: write
@@ -21,6 +16,7 @@ env:
 jobs:
   onboarding:
     runs-on: ubuntu-latest
+    if: false  # disabled intentionally
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/postmortem-postrelease.yml
+++ b/.github/workflows/postmortem-postrelease.yml
@@ -1,18 +1,8 @@
 name: Post-release Postmortem Generation
 
 on:
-  release:
-    types:
-      - published
-
   workflow_dispatch:
-    inputs:
-      previous_tag:
-        description: 'Previous release tag (e.g., v1.0.0)'
-        required: false
-      current_tag:
-        description: 'Current release tag (e.g., v1.1.0)'
-        required: false
+
 
 permissions:
   contents: write
@@ -26,6 +16,7 @@ env:
 jobs:
   post-release:
     runs-on: ubuntu-latest
+    if: false  # disabled intentionally
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/postmortem-prerelease.yml
+++ b/.github/workflows/postmortem-prerelease.yml
@@ -1,25 +1,8 @@
 name: Pre-release Postmortem Check
 
 on:
-  # 在创建 Release 之前手动触发检查
   workflow_dispatch:
-    inputs:
-      base_ref:
-        description: 'Base reference (tag or branch)'
-        required: false
-        default: 'origin/main'
-      head_ref:
-        description: 'Head reference to check'
-        required: false
-        default: 'HEAD'
 
-  # 或者在 PR 合并到 main 时自动检查
-  pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - synchronize
 
 permissions:
   contents: read
@@ -33,8 +16,7 @@ env:
 jobs:
   pre-release-check:
     runs-on: ubuntu-latest
-    # 排除 dependabot 创建的 PR
-    if: github.event_name == 'workflow_dispatch' || github.actor != 'dependabot[bot]'
+    if: false  # disabled intentionally
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ run:
   # 超时时间
   timeout: 5m
   # Go 版本
-  go: "1.24"
+  go: "1.25"
 
 # 输出配置
 output:

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -22,6 +22,7 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "ignoreDeprecations": "6.0",
 
     "baseUrl": ".",
     "paths": {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -135,38 +135,51 @@ export default defineConfig({
     rollupOptions: {
       output: {
         // 手动分割 chunks
-        manualChunks: {
-          // React 核心库
-          "vendor-react": ["react", "react-dom"],
-          // 路由相关
-          "vendor-router": ["react-router-dom"],
-          // UI 相关
-          "vendor-ui": [
-            "@radix-ui/react-avatar",
-            "@radix-ui/react-dropdown-menu",
-            "@radix-ui/react-label",
-            "@radix-ui/react-separator",
-            "@radix-ui/react-slot",
-            "lucide-react",
-            "class-variance-authority",
-            "clsx",
-            "tailwind-merge",
-          ],
-          // 表单和状态管理
-          "vendor-state": [
-            "zustand",
-            "react-hook-form",
-            "@hookform/resolvers",
-            "zod",
-          ],
-          // 国际化
-          "vendor-i18n": [
-            "i18next",
-            "react-i18next",
-            "i18next-browser-languagedetector",
-          ],
-          // 其他工具
-          "vendor-utils": ["axios", "sonner", "next-themes"],
+        manualChunks: (id) => {
+          if (!id.includes("node_modules")) {
+            return undefined;
+          }
+
+          if (id.includes("react") || id.includes("react-dom")) {
+            return "vendor-react";
+          }
+
+          if (id.includes("react-router-dom")) {
+            return "vendor-router";
+          }
+
+          if (
+            id.includes("@radix-ui") ||
+            id.includes("lucide-react") ||
+            id.includes("class-variance-authority") ||
+            id.includes("clsx") ||
+            id.includes("tailwind-merge")
+          ) {
+            return "vendor-ui";
+          }
+
+          if (
+            id.includes("zustand") ||
+            id.includes("react-hook-form") ||
+            id.includes("@hookform/resolvers") ||
+            id.includes("zod")
+          ) {
+            return "vendor-state";
+          }
+
+          if (
+            id.includes("i18next") ||
+            id.includes("react-i18next") ||
+            id.includes("i18next-browser-languagedetector")
+          ) {
+            return "vendor-i18n";
+          }
+
+          if (id.includes("axios") || id.includes("sonner") || id.includes("next-themes")) {
+            return "vendor-utils";
+          }
+
+          return "vendor-misc";
         },
         // 资源文件名格式
         chunkFileNames: "assets/js/[name]-[hash].js",


### PR DESCRIPTION
### Motivation
- Upgrade Go and Node toolchains to recent versions for compatibility and security.
- Improve frontend build performance and caching behavior and relax lockfile strictness to avoid CI failures from minor lock mismatches.
- Temporarily disable automated postmortem workflows that invoke external AI services to prevent unintended runs.

### Description
- CI: bumped Go from `1.24` to `1.25` and Node from `20` to `22`, updated frontend cache key to include `web/package.json`, and changed `pnpm install` to `pnpm install --no-frozen-lockfile --prefer-offline` in `.github/workflows/ci.yml`.
- Lint config: updated `go` version to `1.25` in `.golangci.yml` to match the CI Go version.
- Frontend TS and build: added `"ignoreDeprecations": "6.0"` to `web/tsconfig.app.json` and replaced the static `manualChunks` object with a function in `web/vite.config.ts` to group node_modules into named vendor chunks and provide a fallback `vendor-misc` chunk.
- Postmortem workflows: disabled the onboarding, pre-release, and post-release postmortem workflows by removing triggers/inputs and adding `if: false` guards in the respective `.github/workflows/postmortem-*.yml` files.

### Testing
- No automated test runs were executed as part of this PR; CI workflow definitions were modified and will run on the next push or PR to `main` under the updated configuration.
- YAML and JSON edits were kept syntactically consistent to avoid workflow parse errors, but no integration or unit tests were triggered by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cf51feaa8832f85865b0520003f43)